### PR TITLE
[Logger] fix printed level

### DIFF
--- a/logger.opam
+++ b/logger.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "logger"
-version: "v20230108"
+version: "v20230111"
 synopsis: "simple logger"
 maintainer: "Programming Systems Laboratory, KAIST"
 authors: "Programming Systems Laboratory, KAIST"

--- a/src/logger.ml
+++ b/src/logger.ml
@@ -97,7 +97,7 @@ let log to_console new_line lv =
       in
       F.fprintf formatter "[%s][%s] "
         (string_of_current_time ())
-        (string_of_level !level);
+        (string_of_level lv);
       F.kfprintf
         (fun log_formatter ->
           if new_line then F.fprintf log_formatter "\n";


### PR DESCRIPTION
현재 logger 구현에서는 `set_level`을 통해 세팅할 수 있는 전역변수 `level`이 가리키는 값을 항상 출력하게 되어 있습니다.

이 때문에, 예를 들어 logger를 사용하는 프로그램에서 `Logger.set_level Logger.DEBUG`라고 하면, 그 뒤에 `Logger.debug`를 사용하든 `Logger.info`를 사용하든 항상 로그 파일에 머릿말이 `[YYYYMMDD-HH:MM:SS][DEBUG]`로 출력되는 문제가 있어 이를 고쳤습니다.